### PR TITLE
wasm shims detection

### DIFF
--- a/pkg/agent/containerd/runtimes.go
+++ b/pkg/agent/containerd/runtimes.go
@@ -1,0 +1,57 @@
+//go:build linux
+// +build linux
+
+package containerd
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+
+	"github.com/k3s-io/k3s/pkg/agent/templates"
+	"github.com/sirupsen/logrus"
+)
+
+// findContainerRuntimes returns a list of container runtimes that
+// are available on the system. It checks install locations provided via
+// the potentialRuntimes variable.
+// The binaries are searched at the locations specivied by locationsToCheck.
+// Note: check the given locations in order.
+// The given fs.FS should represent the filesystem root directory to search in.
+func findContainerRuntimes(root fs.FS,
+	potentialRuntimes map[string]templates.ContainerdRuntimeConfig,
+	locationsToCheck []string,
+) map[string]templates.ContainerdRuntimeConfig {
+	// Check these locations in order. The GPU operator's installation should
+	// take precedence over the package manager's installation.
+
+	// Fill in the binary location with just the name of the binary,
+	// and check against each of the possible locations. If a match is found,
+	// set the location to the full path.
+	foundRuntimes := map[string]templates.ContainerdRuntimeConfig{}
+RUNTIME:
+	for runtimeName, runtimeConfig := range potentialRuntimes {
+		for _, location := range locationsToCheck {
+			binaryPath := filepath.Join(location, runtimeConfig.BinaryName)
+			logrus.Debugf("Searching for %s container runtime at /%s", runtimeName, binaryPath)
+			if info, err := fs.Stat(root, binaryPath); err == nil {
+				if info.IsDir() {
+					logrus.Debugf("Found %s container runtime at /%s, but it is a directory. Skipping.", runtimeName, binaryPath)
+					continue
+				}
+				runtimeConfig.BinaryName = filepath.Join("/", binaryPath)
+				logrus.Infof("Found %s container runtime at %s", runtimeName, runtimeConfig.BinaryName)
+				foundRuntimes[runtimeName] = runtimeConfig
+				// Skip to the next runtime to enforce precedence.
+				continue RUNTIME
+			} else {
+				if errors.Is(err, fs.ErrNotExist) {
+					logrus.Debugf("%s container runtime not found at /%s", runtimeName, binaryPath)
+				} else {
+					logrus.Errorf("Error searching for %s container runtime at /%s: %v", runtimeName, binaryPath, err)
+				}
+			}
+		}
+	}
+	return foundRuntimes
+}

--- a/pkg/agent/containerd/runtimes_test.go
+++ b/pkg/agent/containerd/runtimes_test.go
@@ -1,0 +1,214 @@
+//go:build linux
+// +build linux
+
+package containerd
+
+import (
+	"io/fs"
+	"reflect"
+	"testing"
+	"testing/fstest"
+
+	"github.com/k3s-io/k3s/pkg/agent/templates"
+)
+
+func Test_UnitFindRuntimes(t *testing.T) {
+	executable := &fstest.MapFile{Mode: 0755}
+	locationsToCheck := []string{
+		"usr/local/nvidia/toolkit", // Path for nvidia shim when installing via GPU Operator
+		"opt/kwasm/bin",            // Path for wasm shim when installing via the kwasm operator
+		"usr/bin",                  // Path when installing via package manager
+		"usr/sbin",                 // Path when installing via package manager
+	}
+
+	potentialRuntimes := map[string]templates.ContainerdRuntimeConfig{
+		"nvidia": {
+			RuntimeType: "io.containerd.runc.v2",
+			BinaryName:  "nvidia-container-runtime",
+		},
+		"spin": {
+			RuntimeType: "io.containerd.spin.v2",
+			BinaryName:  "containerd-shim-spin-v1",
+		},
+	}
+
+	type args struct {
+		root              fs.FS
+		potentialRuntimes map[string]templates.ContainerdRuntimeConfig
+		locationsToCheck  []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]templates.ContainerdRuntimeConfig
+	}{
+		{
+			name: "No runtimes",
+			args: args{
+				root:              fstest.MapFS{},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{},
+		},
+		{
+			name: "Nvidia runtime in /usr/bin",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime": executable,
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
+				},
+			},
+		},
+		{
+			name: "Two runtimes in separate directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime":      executable,
+					"opt/kwasm/bin/containerd-shim-spin-v1": executable,
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
+				},
+				"spin": {
+					RuntimeType: "io.containerd.spin.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-spin-v1",
+				},
+			},
+		},
+		{
+			name: "Same runtime in two directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/containerd-shim-spin-v1":       executable,
+					"opt/kwasm/bin/containerd-shim-spin-v1": executable,
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"spin": {
+					RuntimeType: "io.containerd.spin.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-spin-v1",
+				},
+			},
+		},
+		{
+			name: "Both runtimes in /usr/bin",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/containerd-shim-spin-v1":  executable,
+					"usr/bin/nvidia-container-runtime": executable,
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
+				},
+				"spin": {
+					RuntimeType: "io.containerd.spin.v2",
+					BinaryName:  "/usr/bin/containerd-shim-spin-v1",
+				},
+			},
+		},
+		{
+			name: "Both runtimes in both directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+					"usr/bin/nvidia-container-runtime":                  executable,
+					"usr/bin/containerd-shim-spin-v1":                   executable,
+					"opt/kwasm/bin/containerd-shim-spin-v1":             executable,
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
+				},
+				"spin": {
+					RuntimeType: "io.containerd.spin.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-spin-v1",
+				},
+			},
+		},
+		{
+			name: "Both runtimes in /usr/bin and one duplicate in /usr/local/nvidia/toolkit",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime":                  executable,
+					"usr/bin/containerd-shim-spin-v1":                   executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime": executable,
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"spin": {
+					RuntimeType: "io.containerd.spin.v2",
+					BinaryName:  "/usr/bin/containerd-shim-spin-v1",
+				},
+				"nvidia": {
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/local/nvidia/toolkit/nvidia-container-runtime",
+				},
+			},
+		},
+		{
+			name: "Runtime is a directory",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime": &fstest.MapFile{
+						Mode: fs.ModeDir,
+					},
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{},
+		},
+		{
+			name: "Runtime in both directories, but one is a directory",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/nvidia-container-runtime": executable,
+					"usr/local/nvidia/toolkit/nvidia-container-runtime": &fstest.MapFile{
+						Mode: fs.ModeDir,
+					},
+				},
+				locationsToCheck:  locationsToCheck,
+				potentialRuntimes: potentialRuntimes,
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"nvidia": {
+					RuntimeType: "io.containerd.runc.v2",
+					BinaryName:  "/usr/bin/nvidia-container-runtime",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findContainerRuntimes(tt.args.root, tt.args.potentialRuntimes, tt.args.locationsToCheck); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findContainerRuntimes() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/containerd/runwasi.go
+++ b/pkg/agent/containerd/runwasi.go
@@ -1,0 +1,60 @@
+//go:build linux
+// +build linux
+
+package containerd
+
+import (
+	"io/fs"
+
+	"github.com/k3s-io/k3s/pkg/agent/templates"
+)
+
+// findWasiRuntimes returns a list of WebAssembly (WASI) container runtimes that
+// are available on the system. It checks install locations used by the kwasm
+// operator and by system package managers. The kwasm operator installation
+// takes precedence over the system package manager installation.
+// The given fs.FS should represent the filesystem root directory to search in.
+func findWasiRuntimes(root fs.FS) map[string]templates.ContainerdRuntimeConfig {
+	// Check these locations in order. The GPU operator's installation should
+	// take precedence over the package manager's installation.
+	locationsToCheck := []string{
+		"opt/kwasm/bin", // Path when installing via kwasm Operator
+		"usr/bin",       // Path when installing via package manager
+		"usr/sbin",      // Path when installing via package manager
+	}
+
+	// Fill in the binary location with just the name of the binary,
+	// and check against each of the possible locations. If a match is found,
+	// set the location to the full path.
+	potentialRuntimes := map[string]templates.ContainerdRuntimeConfig{
+		"lunatic": {
+			RuntimeType: "io.containerd.lunatic.v2",
+			BinaryName:  "containerd-shim-lunatic-v1",
+		},
+		"slight": {
+			RuntimeType: "io.containerd.slight.v2",
+			BinaryName:  "containerd-shim-slight-v1",
+		},
+		"spin": {
+			RuntimeType: "io.containerd.spin.v2",
+			BinaryName:  "containerd-shim-spin-v1",
+		},
+		"wws": {
+			RuntimeType: "io.containerd.wws.v2",
+			BinaryName:  "containerd-shim-wws-v1",
+		},
+		"wasmedge": {
+			RuntimeType: "io.containerd.wasmedge.v2",
+			BinaryName:  "containerd-shim-wasmedge-v1",
+		},
+		"wasmer": {
+			RuntimeType: "io.containerd.wasmer.v2",
+			BinaryName:  "containerd-shim-wasmer-v1",
+		},
+		"wasmtime": {
+			RuntimeType: "io.containerd.wasmtime.v2",
+			BinaryName:  "containerd-shim-wasmtime-v1",
+		},
+	}
+	return findContainerRuntimes(root, potentialRuntimes, locationsToCheck)
+}

--- a/pkg/agent/containerd/runwasi_test.go
+++ b/pkg/agent/containerd/runwasi_test.go
@@ -1,0 +1,167 @@
+//go:build linux
+// +build linux
+
+package containerd
+
+import (
+	"io/fs"
+	"reflect"
+	"testing"
+	"testing/fstest"
+
+	"github.com/k3s-io/k3s/pkg/agent/templates"
+)
+
+func Test_UnitFindWasiContainerRuntimes(t *testing.T) {
+	executable := &fstest.MapFile{Mode: 0755}
+	type args struct {
+		root fs.FS
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]templates.ContainerdRuntimeConfig
+	}{
+		{
+			name: "No runtimes",
+			args: args{
+				root: fstest.MapFS{},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{},
+		},
+		{
+			name: "wasmtime runtime in /usr/sbin",
+			args: args{
+				root: fstest.MapFS{
+					"usr/sbin/containerd-shim-wasmtime-v1": executable,
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"wasmtime": {
+					RuntimeType: "io.containerd.wasmtime.v2",
+					BinaryName:  "/usr/sbin/containerd-shim-wasmtime-v1",
+				},
+			},
+		},
+		{
+			name: "lunatic runtime in /opt/kwasm/bin/",
+			args: args{
+				root: fstest.MapFS{
+					"opt/kwasm/bin/containerd-shim-lunatic-v1": executable,
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"lunatic": {
+					RuntimeType: "io.containerd.lunatic.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-lunatic-v1",
+				},
+			},
+		},
+		{
+			name: "Two runtimes in separate directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/containerd-shim-wasmer-v1":       executable,
+					"opt/kwasm/bin/containerd-shim-slight-v1": executable,
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"slight": {
+					RuntimeType: "io.containerd.slight.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-slight-v1",
+				},
+				"wasmer": {
+					RuntimeType: "io.containerd.wasmer.v2",
+					BinaryName:  "/usr/bin/containerd-shim-wasmer-v1",
+				},
+			},
+		},
+		{
+			name: "Same runtime in two directories",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/containerd-shim-wasmedge-v1":       executable,
+					"opt/kwasm/bin/containerd-shim-wasmedge-v1": executable,
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"wasmedge": {
+					RuntimeType: "io.containerd.wasmedge.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-wasmedge-v1",
+				},
+			},
+		},
+		{
+			name: "All runtimes in /usr/bin",
+			args: args{
+				root: fstest.MapFS{
+					"usr/bin/containerd-shim-lunatic-v1":  executable,
+					"usr/bin/containerd-shim-slight-v1":   executable,
+					"usr/bin/containerd-shim-spin-v1":     executable,
+					"usr/bin/containerd-shim-wws-v1":      executable,
+					"usr/bin/containerd-shim-wasmedge-v1": executable,
+					"usr/bin/containerd-shim-wasmer-v1":   executable,
+					"usr/bin/containerd-shim-wasmtime-v1": executable,
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"lunatic": {
+					RuntimeType: "io.containerd.lunatic.v2",
+					BinaryName:  "/usr/bin/containerd-shim-lunatic-v1",
+				},
+				"slight": {
+					RuntimeType: "io.containerd.slight.v2",
+					BinaryName:  "/usr/bin/containerd-shim-slight-v1",
+				},
+				"spin": {
+					RuntimeType: "io.containerd.spin.v2",
+					BinaryName:  "/usr/bin/containerd-shim-spin-v1",
+				},
+				"wws": {
+					RuntimeType: "io.containerd.wws.v2",
+					BinaryName:  "/usr/bin/containerd-shim-wws-v1",
+				},
+				"wasmedge": {
+					RuntimeType: "io.containerd.wasmedge.v2",
+					BinaryName:  "/usr/bin/containerd-shim-wasmedge-v1",
+				},
+				"wasmer": {
+					RuntimeType: "io.containerd.wasmer.v2",
+					BinaryName:  "/usr/bin/containerd-shim-wasmer-v1",
+				},
+				"wasmtime": {
+					RuntimeType: "io.containerd.wasmtime.v2",
+					BinaryName:  "/usr/bin/containerd-shim-wasmtime-v1",
+				},
+			},
+		},
+		{
+			name: "Both runtimes in both directories",
+			args: args{
+				root: fstest.MapFS{
+					"opt/kwasm/bin/containerd-shim-slight-v1":   executable,
+					"opt/kwasm/bin/containerd-shim-wasmtime-v1": executable,
+					"usr/bin/containerd-shim-slight-v1":         executable,
+					"usr/bin/containerd-shim-wasmtime-v1":       executable,
+				},
+			},
+			want: map[string]templates.ContainerdRuntimeConfig{
+				"slight": {
+					RuntimeType: "io.containerd.slight.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-slight-v1",
+				},
+				"wasmtime": {
+					RuntimeType: "io.containerd.wasmtime.v2",
+					BinaryName:  "/opt/kwasm/bin/containerd-shim-wasmtime-v1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findWasiRuntimes(tt.args.root); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findWasiRuntimes() = %+v\nWant = %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- HTML Comments can be left in place or removed. -->
<!-- Please see our contributing guide at https://github.com/k3s-io/k3s/blob/master/CONTRIBUTING.md for guidance on opening pull requests -->

#### Proposed Changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

As developers start to experiment building WebAssembly applications, they desire to deploy these workloads on top of Kubernetes, using the same paradigm of "traditional" applications.
The [`containerd/runwasi`](https://github.com/containerd/runwasi) project provides a way to integrate these workloads into Kubernetes.

The WebAssembly workloads require dedicated containerd runtimes to be installed and configured on the node. This PR provides a way to automatically discover the already installed runtimes and properly configure containerd to consume them.

The PR doesn't focus on shipping the pre-built runtimes as part of the k3s installation. I think this should be done by another dedicated PR.

#### Types of Changes

<!-- What types of changes does your code introduce to K3s? Bugfix, New Feature, Breaking Change, etc -->

This PR introduces a new feature. It does that by leveraging the same mechanism used to discover the nvidia runtimes. As you will see, the existing nvidia discovery code has been refactored. Now we have a generic discovery mechanism that can be reused to discover any kind of containerd runtime.

This can be useful not only to add the WebAssembly runtimes, but to discover and configure other runtimes such as gVisor, Kata, ...

#### Verification

<!-- How can the changes be verified? Please provide whatever additional information necessary to help verify the proposed changes. -->

On a node where k3s agent is about to be installed create the following files:

- `/usr/bin/containerd-shim-lunatic-v1`
- `/usr/sbin/containerd-shim-spin-v1`
- `/opt/kwasm/bin/containerd-shim-lunatic-v1`
- `/usr/bin/nvidia-container-runtime`
- `/usr/bin/nvidia-container-runtime-experimental`

All these files can be created with a `touch` command, they must have the executable permission set.

Install the k3s agent, check the containerd `config.toml`. Each runtime should have a dedicated section inside of the file.

#### Testing

<!-- Is this change covered by testing? If not, consider adding a Unit or Integration test. -->
<!-- See https://github.com/k3s-io/k3s/blob/master/tests/TESTING.md for more info -->

The new code is covered by dedicated unit tests.

#### Linked Issues

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request. If you are opening a PR without a corresponding issue please consider creating one first, at https://github.com/k3s-io/k3s/issues . A functional example will greatly help QA with verifying/reproducing a bug or testing new features. -->

This PR partially fixes https://github.com/k3s-io/k3s/issues/8700 . This PR doesn't handle the registration of the `RuntimeClass` resource for each of the runtimes discovered.

#### User-Facing Change

<!--
Does this PR introduce a user-facing change? If no, just write "NONE" in the release-note block below.
If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
automatic discovery of WebAssembly runtimes
```

#### Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

This PR is somehow related with https://github.com/k3s-io/k3s/pull/6872 . I've discussed with @brandon an alternative approach to his orignal PR. The idea is to focus on the discovery phase of the WebAssembly runtimes. We can expect the user has somehow installed them on the nodes. We will create another PR later on that changes the build scripts of k3s to ensure the most relevant runtimes are pre-installed with k3s.
